### PR TITLE
Use the actual port number on the webpage

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -80,8 +80,8 @@
     $(function () {
       document.querySelector('#wakelockStatus').innerHTML = wakeLockNotice;
 
-      var host = location.hostname + ":8080";
-      //var host = "192.168.1.112:8080"
+      var host = location.hostname + ":" + location.port;
+      
       cam = new SentryPicam("videoContainer", 'ws://' + host);
 
       monitorStream();


### PR DESCRIPTION
This small change will allow the user selected non-default port to be used by the webpage.